### PR TITLE
Refactored configuration to allow for key to be passed in directly

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,13 +16,22 @@ This gem has been publised as `cloudfront-signer`. Use `gem install cloudfront-s
 
 Alternatively, place a copy of cloudfront-signer.rb (and the cloundfront-signer sub directory) in your lib directory.
 
-In either case the signing class must be configured - supplying the path to a signing key. Create the initializer by running:
+In either case the signing class must be configured - supplying the path to a signing key, or supplying the signing key directly as a string along with the `key_pair_id`. Create the initializer by running:
 
 ```
 bundle exec rails g cloudfront:install
 ```
 
 and customizing the resulting `config/initializers/cloudfront-signer.rb` file.
+
+### Generated `cloudfront-signer.rb`
+
+    AWS::CF::Signer.configure do |config|
+      config.key_path = '/path/to/keyfile.pem'
+      # config.key = ENV.fetch('PRIVATE_KEY') # key_path not required if key supplied directly
+      config.key_pair_id  = "XXYYZZ"
+      config.default_expires = 3600
+    end
 
 ## Usage
 

--- a/lib/generators/cloudfront/install/templates/cloudfront-signer.rb
+++ b/lib/generators/cloudfront/install/templates/cloudfront-signer.rb
@@ -1,5 +1,6 @@
 AWS::CF::Signer.configure do |config|
   config.key_path = '/path/to/keyfile.pem'
+  # config.key = ENV.fetch('PRIVATE_KEY') # key_path not required if key supplied directly
   config.key_pair_id  = "XXYYZZ"
   config.default_expires = 3600
 end

--- a/spec/signer_spec.rb
+++ b/spec/signer_spec.rb
@@ -1,56 +1,24 @@
 require 'spec_helper'
 
 describe AWS::CF::Signer do
+  let(:key_pair_id) { 'APKAIKUROOUNR2BAFUUU' }
+  let(:key_path) { File.expand_path(File.dirname(__FILE__) + "/keys/pk-#{key_pair_id}.pem") }
+  let(:key) { File.readlines(key_path).join("") }
 
-  let(:key_path) { File.expand_path(File.dirname(__FILE__) + '/keys/pk-APKAIKUROOUNR2BAFUUU.pem') }
-
-  before(:each) do
-    AWS::CF::Signer.configure do |config|
-      config.key_path = key_path
-      #config.key_pair_id  = "XXYYZZ"
-      #config.default_expires = 3600
+  context "configured with key and key_pair_id" do
+    before do
+      AWS::CF::Signer.configure do |config|
+        config.key_pair_id = key_pair_id
+        config.key = key
+      end
     end
-  end
-
-  describe "before default use" do
 
     it "should be configured" do
       AWS::CF::Signer.is_configured?.should eql(true)
     end
 
-    it "should expire urls and paths in one hour by default" do
-      AWS::CF::Signer.default_expires.should eql(3600)
-    end
-
-    it "should optionally be configured to expire urls and paths in ten minutes" do
-      AWS::CF::Signer.default_expires =  600
-      AWS::CF::Signer.default_expires.should eql(600)
-      AWS::CF::Signer.default_expires =  nil
-    end
-  end
-
-  describe "when signing a url" do
-
-    it "should remove spaces from the url" do
-      url = "http://somedomain.com/sign me"
-      result = AWS::CF::Signer.sign_url(url)
-      (result =~ /\s/).should be_nil
-    end
-
-    it "should not html encode the signed url by default" do
-      url = "http://somedomain.com/someresource?opt1=one&opt2=two"
-      result = AWS::CF::Signer.sign_url(url)
-      (result =~ /\?/).should_not be_nil
-      (result =~ /=/).should_not be_nil
-      (result =~ /&/).should_not be_nil
-    end
-
-    it "should optionally html encode the signed url" do
-      url = "http://somedomain.com/someresource?opt1=one&opt2=two"
-      result = AWS::CF::Signer.sign_url_safe(url)
-      (result =~ /\?/).should be_nil
-      (result =~ /=/).should be_nil
-      (result =~ /&/).should be_nil
+    it "sets the private_key" do
+      AWS::CF::Signer.send(:private_key).should be_instance_of OpenSSL::PKey::RSA
     end
 
     it "should expire in one hour by default" do
@@ -58,23 +26,85 @@ describe AWS::CF::Signer do
       result = AWS::CF::Signer.sign_url(url)
       get_query_value(result, 'Expires').to_i.should eql((Time.now + 3600).to_i)
     end
-
-    it "should optionally expire in ten minutes" do
-      url = "http://somedomain.com/sign me"
-      result = AWS::CF::Signer.sign_url(url, :expires => Time.now + 600)
-      get_query_value(result, 'Expires').to_i.should eql((Time.now + 600 ).to_i)
-    end
-
   end
 
+  context "configured with key_path" do
 
-  describe "when signing a path" do
-
-    it "should not remove spaces from the path" do
-      path = "/someprefix/sign me"
-      result = AWS::CF::Signer.sign_path(path)
-      (result =~ /\s/).should_not be_nil
+    before(:each) do
+      AWS::CF::Signer.configure do |config|
+        config.key_path = key_path
+        #config.key_pair_id  = "XXYYZZ"
+        #config.default_expires = 3600
+      end
     end
 
+    describe "before default use" do
+
+      it "should be configured" do
+        AWS::CF::Signer.is_configured?.should eql(true)
+      end
+
+      it "sets the private_key" do
+        AWS::CF::Signer.send(:private_key).should be_instance_of OpenSSL::PKey::RSA
+      end
+
+      it "should expire urls and paths in one hour by default" do
+        AWS::CF::Signer.default_expires.should eql(3600)
+      end
+
+      it "should optionally be configured to expire urls and paths in ten minutes" do
+        AWS::CF::Signer.default_expires =  600
+        AWS::CF::Signer.default_expires.should eql(600)
+        AWS::CF::Signer.default_expires =  nil
+      end
+    end
+
+    describe "when signing a url" do
+
+      it "should remove spaces from the url" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url)
+        (result =~ /\s/).should be_nil
+      end
+
+      it "should not html encode the signed url by default" do
+        url = "http://somedomain.com/someresource?opt1=one&opt2=two"
+        result = AWS::CF::Signer.sign_url(url)
+        (result =~ /\?/).should_not be_nil
+        (result =~ /=/).should_not be_nil
+        (result =~ /&/).should_not be_nil
+      end
+
+      it "should optionally html encode the signed url" do
+        url = "http://somedomain.com/someresource?opt1=one&opt2=two"
+        result = AWS::CF::Signer.sign_url_safe(url)
+        (result =~ /\?/).should be_nil
+        (result =~ /=/).should be_nil
+        (result =~ /&/).should be_nil
+      end
+
+      it "should expire in one hour by default" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url)
+        get_query_value(result, 'Expires').to_i.should eql((Time.now + 3600).to_i)
+      end
+
+      it "should optionally expire in ten minutes" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url, :expires => Time.now + 600)
+        get_query_value(result, 'Expires').to_i.should eql((Time.now + 600 ).to_i)
+      end
+
+    end
+
+    describe "when signing a path" do
+
+      it "should not remove spaces from the path" do
+        path = "/someprefix/sign me"
+        result = AWS::CF::Signer.sign_path(path)
+        (result =~ /\s/).should_not be_nil
+      end
+
+    end
   end
 end


### PR DESCRIPTION
I use `cloudfront-signer` on Heroku and like to follow their convention of keeping sensitive data out of the git repo using ENV variables.

In this case I would prefer to keep the key encoded as a string stored as an ENV variable on  Heroku, and so would prefer to supply the key directly, along with the key_pair_id as seen in the following:

``` ruby
AWS::CF::Signer.configure do |config|
  config.key = ENV.fetch('PRIVATE_KEY')
  config.key_pair_id  = "XXYYZZ"
end
```
