### PR TITLE
Support for providing a signing key as a string instead of a file

### DIFF
--- a/lib/cloudfront-signer.rb
+++ b/lib/cloudfront-signer.rb
@@ -35,7 +35,17 @@ module AWS
         def key_path=(path)
           raise ArgumentError.new("The signing key could not be found at #{path}") unless File.exists?(path)
           @key_path = path
-          @key = OpenSSL::PKey::RSA.new(File.readlines(path).join(""))
+          self.key_string = File.readlines(path).join("")
+        end
+
+        def key_string=(key_string)
+          raise ArgumentError, "key_string must be a string" if key_string.nil?
+          @key_string = key_string
+          @key = OpenSSL::PKey::RSA.new(key_string)
+        end
+
+        def key_string
+          @key_string
         end
 
         # Public: Provides an accessor to the key_path 
@@ -94,11 +104,11 @@ module AWS
 
         yield self if block_given?
 
-        raise ArgumentError.new("You must supply the path to a PEM format RSA key pair.") unless self.key_path
+        raise ArgumentError.new("You must supply the PEM format RSA key pair as a string (or path to the file).") unless private_key
 
         unless @key_pair_id
-          @key_pair_id = extract_key_pair_id(self.key_path)
-          raise ArgumentError.new("The Cloudfront signing key id could not be inferred from #{self.key_path}. Please supply the key pair id as a configuration argument.") unless @key_pair_id 
+          @key_pair_id = extract_key_pair_id(self.key_path) if self.key_path
+          raise ArgumentError.new("The Cloudfront signing key id could not be inferred from #{self.key_path}. Please supply the key pair id as a configuration argument.") unless @key_pair_id
         end
       end
 
@@ -109,23 +119,18 @@ module AWS
         @key_pair_id = nil
       end
 
-      # Public: Provides a configuration check method which tests to see 
+      # Public: Provides a configuration check method which tests to see
       # that the key_path, key_pair_id and private key values have all been set.
       #
       # Returns a Boolean value indicating that settings are present.
       def self.is_configured?
-        (self.key_path.nil? || self.key_pair_id.nil? || private_key.nil?) ? false : true
+        (key_pair_id.nil? || private_key.nil?) ? false : true
       end
 
-      # Public: Sign a url - encoding any spaces in the url before signing. CloudFront 
       # Public: Sign a url - encoding any spaces in the url before signing. CloudFront
       # stipulates that signed URLs must not contain spaces (as opposed to stream
-      # paths/filenames which CAN contain spaces). 
       # paths/filenames which CAN contain spaces).
       #
-      # Returns a String 
-      def self.sign_url(subject, policy_options = {}) 
-        self.sign(subject, {:remove_spaces => true}, policy_options) 
       # Returns a String
       def self.sign_url(subject, policy_options = {})
         self.sign(subject, {:remove_spaces => true}, policy_options)

--- a/spec/signer_spec.rb
+++ b/spec/signer_spec.rb
@@ -4,77 +4,116 @@ describe AWS::CF::Signer do
 
   let(:key_path) { File.expand_path(File.dirname(__FILE__) + '/keys/pk-APKAIKUROOUNR2BAFUUU.pem') }
 
-  before(:each) do
-    AWS::CF::Signer.configure do |config|
-      config.key_path = key_path
-      #config.key_pair_id  = "XXYYZZ"
-      #config.default_expires = 3600
+  describe "configuring with a string key" do
+    let(:key_string) { File.readlines(key_path).join("") }
+    let(:key_pair_id) { "ABCKEEQRNKA" }
+
+    def configure
+      AWS::CF::Signer.reset!
+      AWS::CF::Signer.configure do |config|
+        config.key_string = key_string
+        config.key_pair_id = key_pair_id
+      end
     end
-  end
 
-  describe "before default use" do
-
-    it "should be configured" do
+    it "should be_configured" do
+      configure
       AWS::CF::Signer.is_configured?.should eql(true)
     end
 
-    it "should expire urls and paths in one hour by default" do
-      AWS::CF::Signer.default_expires.should eql(3600)
+    context "without a key string specified" do
+      let(:key_string) { nil }
+      it "should raise an error specifying the key string or path is required" do
+        expect { configure }.to raise_error(ArgumentError)
+      end
     end
 
-    it "should optionally be configured to expire urls and paths in ten minutes" do
-      AWS::CF::Signer.default_expires =  600
-      AWS::CF::Signer.default_expires.should eql(600)
-      AWS::CF::Signer.default_expires =  nil
-    end
-  end
+    context "without a key pair specified" do
+      let(:key_pair_id) { nil }
 
-  describe "when signing a url" do
-
-    it "should remove spaces from the url" do
-      url = "http://somedomain.com/sign me"
-      result = AWS::CF::Signer.sign_url(url)
-      (result =~ /\s/).should be_nil
-    end
-
-    it "should not html encode the signed url by default" do
-      url = "http://somedomain.com/someresource?opt1=one&opt2=two"
-      result = AWS::CF::Signer.sign_url(url)
-      (result =~ /\?/).should_not be_nil
-      (result =~ /=/).should_not be_nil
-      (result =~ /&/).should_not be_nil
-    end
-
-    it "should optionally html encode the signed url" do
-      url = "http://somedomain.com/someresource?opt1=one&opt2=two"
-      result = AWS::CF::Signer.sign_url_safe(url)
-      (result =~ /\?/).should be_nil
-      (result =~ /=/).should be_nil
-      (result =~ /&/).should be_nil
-    end
-
-    it "should expire in one hour by default" do
-      url = "http://somedomain.com/sign me"
-      result = AWS::CF::Signer.sign_url(url)
-      get_query_value(result, 'Expires').to_i.should eql((Time.now + 3600).to_i)
-    end
-
-    it "should optionally expire in ten minutes" do
-      url = "http://somedomain.com/sign me"
-      result = AWS::CF::Signer.sign_url(url, :expires => Time.now + 600)
-      get_query_value(result, 'Expires').to_i.should eql((Time.now + 600 ).to_i)
+      it "should raise an error specifying the key pair id is required" do
+        expect { configure }.to raise_error ArgumentError
+      end
     end
 
   end
 
+  describe "configuring with a PEM file" do
 
-  describe "when signing a path" do
-
-    it "should not remove spaces from the path" do
-      path = "/someprefix/sign me"
-      result = AWS::CF::Signer.sign_path(path)
-      (result =~ /\s/).should_not be_nil
+    before(:each) do
+      AWS::CF::Signer.reset!
+      AWS::CF::Signer.configure do |config|
+        config.key_path = key_path
+        #config.key_pair_id  = "XXYYZZ"
+        #config.default_expires = 3600
+      end
     end
 
+
+    describe "before default use" do
+
+      it "should be configured" do
+        AWS::CF::Signer.is_configured?.should eql(true)
+      end
+
+      it "should expire urls and paths in one hour by default" do
+        AWS::CF::Signer.default_expires.should eql(3600)
+      end
+
+      it "should optionally be configured to expire urls and paths in ten minutes" do
+        AWS::CF::Signer.default_expires =  600
+        AWS::CF::Signer.default_expires.should eql(600)
+        AWS::CF::Signer.default_expires =  nil
+      end
+    end
+
+    describe "when signing a url" do
+
+      it "should remove spaces from the url" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url)
+        (result =~ /\s/).should be_nil
+      end
+
+      it "should not html encode the signed url by default" do
+        url = "http://somedomain.com/someresource?opt1=one&opt2=two"
+        result = AWS::CF::Signer.sign_url(url)
+        (result =~ /\?/).should_not be_nil
+        (result =~ /=/).should_not be_nil
+        (result =~ /&/).should_not be_nil
+      end
+
+      it "should optionally html encode the signed url" do
+        url = "http://somedomain.com/someresource?opt1=one&opt2=two"
+        result = AWS::CF::Signer.sign_url_safe(url)
+        (result =~ /\?/).should be_nil
+        (result =~ /=/).should be_nil
+        (result =~ /&/).should be_nil
+      end
+
+      it "should expire in one hour by default" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url)
+        get_query_value(result, 'Expires').to_i.should eql((Time.now + 3600).to_i)
+      end
+
+      it "should optionally expire in ten minutes" do
+        url = "http://somedomain.com/sign me"
+        result = AWS::CF::Signer.sign_url(url, :expires => Time.now + 600)
+        get_query_value(result, 'Expires').to_i.should eql((Time.now + 600 ).to_i)
+      end
+
+    end
+
+
+    describe "when signing a path" do
+
+      it "should not remove spaces from the path" do
+        path = "/someprefix/sign me"
+        result = AWS::CF::Signer.sign_path(path)
+        (result =~ /\s/).should_not be_nil
+      end
+
+    end
   end
 end


### PR DESCRIPTION
In environments like Heroku, it is common to provide secrets via env vars, and not to check them into your source repository.

This change adds a new config option, `key_string`.  If this is provided, then `key_pair_id` must also be provided, since it cannot be inferred by any filename.

The original implementation of `key_path=` now delegates to `key_string=` in order to create the underlying RSA key.

Added specs for this configuration as well, and all specs currently pass.
