### PR TITLE
Separates url building and signing

### DIFF
--- a/lib/cloudfront-signer.rb
+++ b/lib/cloudfront-signer.rb
@@ -130,7 +130,7 @@ module AWS
       #
       # Returns a String
       def self.sign_url(subject, policy_options = {})
-        self.build_url(subject, {:remove_spaces => true}, policy_options)
+        self.sign(subject, {:remove_spaces => true}, policy_options)
       end
 
 
@@ -139,7 +139,7 @@ module AWS
       #
       # Returns a String
       def self.sign_url_safe(subject, policy_options = {})
-        self.build_url(subject, {:remove_spaces => true, :html_escape => true}, policy_options)
+        self.sign(subject, {:remove_spaces => true, :html_escape => true}, policy_options)
       end
 
       # Public: Sign a stream path part or filename (spaces are allowed in stream paths
@@ -147,21 +147,21 @@ module AWS
       #
       # Returns a String
       def self.sign_path(subject, policy_options ={})
-        self.build_url(subject, {:remove_spaces => false}, policy_options)
+        self.sign(subject, {:remove_spaces => false}, policy_options)
       end
 
       # Public: Sign a stream path or filename and HTML encode the result.
       #
       # Returns a String
       def self.sign_path_safe(subject, policy_options ={})
-        self.build_url(subject, {:remove_spaces => false, :html_escape => true}, policy_options)
+        self.sign(subject, {:remove_spaces => false, :html_escape => true}, policy_options)
       end
 
       # Public: Builds a signed url or stream resource name with optional configuration and
       # policy options
       #
       # Returns a String
-      def self.build_url(subject, configuration_options = {}, policy_options = {})
+      def self.sign(subject, configuration_options = {}, policy_options = {})
         # If the url or stream path already has a query string parameter - append to that.
         separator = subject =~ /\?/ ? '&' : '?'
 
@@ -169,7 +169,7 @@ module AWS
           subject.gsub!(/\s/, "%20")
         end
 
-        result = subject + separator + self.sign(subject, policy_options).collect{ |k,v| "#{k}=#{v}" }.join('&')
+        result = subject + separator + self.signed_params(subject, policy_options).collect{ |k,v| "#{k}=#{v}" }.join('&')
 
         if configuration_options[:html_escape]
           return html_encode(result)
@@ -182,7 +182,7 @@ module AWS
       # It returns raw params to be used in urls or cookies
       #
       # Returns a Hash
-      def self.sign(subject, policy_options = {})
+      def self.signed_params(subject, policy_options = {})
         result = {}
 
         if policy_options[:policy_file]


### PR DESCRIPTION
## How
To be used in signing cookies. From within example.com or a subdomain of example.com (this is important, because the browser won't allow Rails to set cookies for a domain other than the one serving the page.)

```ruby
# In a controller, before serving the images
before_action :set_cookie

def set_cookie
  signed_params = AWS::CF::Signer.sign(
                    nil,
                    resource: 'http://images.example.com/*',
                    expires: 1.day.from_now
                  )

  signed_params.each do |name, value|
    cookies["CloudFront-#{name}"] = { value: value,
                                      domain: :all,
                                      httponly: true }
  end
end
```

A custom policy is built allowing the user access to all images inside _http://images.example.com/_:

```html
<img src="http://images.example.com/image1.jpg" alt="Image 1" />
<img src="http://images.example.com/image2.jpg" alt="Image 2" />
<img src="http://images.example.com/business/image1.jpg" alt="Image 1" />
```

## Why
This is important when:
> You want to provide access to multiple restricted files, for example, all of the files for a video in HLS format or all of the files in the subscribers' area of a website.

As described by [Choosing Between Signed URLs and Signed Cookies](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-choosing-signed-urls-cookies.html)

___

This PR breaks background compatibility of those using `sign` directly, but not `sign_url`, `sign_url_safe`, `sign_path` and `sign_path_safe`. We could simply rename the new method to keep background compatibility, but I thought this made the most sense, semantically:

* `sign` gets all required parts of the signature as described by CloudFront documents. And can be used independently to support signed cookies.
* `build_url` uses sign to build a signed url.