### PR TITLE
Downcased AWS Module to Aws

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ and customizing the resulting `config/initializers/cloudfront-signer.rb` file.
 
 ### Generated `cloudfront-signer.rb`
 
-    AWS::CF::Signer.configure do |config|
+    Aws::CF::Signer.configure do |config|
       config.key_path = '/path/to/keyfile.pem'
       # config.key = ENV.fetch('PRIVATE_KEY') # key_path not required if key supplied directly
       config.key_pair_id  = "XXYYZZ"
@@ -43,19 +43,19 @@ and customizing the resulting `config/initializers/cloudfront-signer.rb` file.
 
 Call the class `sign_url` or `sign_path` method with optional policy settings.
 
-    AWS::CF::Signer.sign_url 'http://mydomain/path/to/my/content'
+    Aws::CF::Signer.sign_url 'http://mydomain/path/to/my/content'
 
 or
 
-    AWS::CF::Signer.sign_url 'http://mydomain/path/to/my/content', :expires => Time.now + 600
+    Aws::CF::Signer.sign_url 'http://mydomain/path/to/my/content', :expires => Time.now + 600
 
 Streaming paths can be signed with the `sign_path` method.
 
-    AWS::CF::Signer.sign_path 'path/to/my/content'
+    Aws::CF::Signer.sign_path 'path/to/my/content'
 
 or
 
-    AWS::CF::Signer.sign_path 'path/to/my/content', :expires => Time.now + 600
+    Aws::CF::Signer.sign_path 'path/to/my/content', :expires => Time.now + 600
 
 
 Both `sign_url` and `sign_path` have _safe_ versions that HTML encode the result allowing signed paths or urls to be placed in HTML markup. The 'non'-safe versions can be used for placing signed urls or paths in JavaScript blocks or Flash params.
@@ -65,7 +65,7 @@ Both `sign_url` and `sign_path` have _safe_ versions that HTML encode the result
 
 See Example Custom Policy 1 at above AWS doc link
 
-    url = AWS::CF::Signer.sign_url('http://d604721fxaaqy9.cloudfront.net/training/orientation.avi',
+    url = Aws::CF::Signer.sign_url('http://d604721fxaaqy9.cloudfront.net/training/orientation.avi',
             :expires   => 'Sat, 14 Nov 2009 22:20:00 GMT',
             :resource => 'http://d604721fxaaqy9.cloudfront.net/training/*',
             :ip_range => '145.168.143.0/24'
@@ -73,7 +73,7 @@ See Example Custom Policy 1 at above AWS doc link
 
 See Example Custom Policy 2 at above AWS doc link
 
-    url = AWS::CF::Signer.sign_url('http://d84l721fxaaqy9.cloudfront.net/downloads/pictures.tgz',
+    url = Aws::CF::Signer.sign_url('http://d84l721fxaaqy9.cloudfront.net/downloads/pictures.tgz',
             :starting => 'Thu, 30 Apr 2009 06:43:10 GMT',
             :expires   => 'Fri, 16 Oct 2009 06:31:56 GMT',
             :resource => 'http://*',
@@ -82,7 +82,7 @@ See Example Custom Policy 2 at above AWS doc link
 
 You can also pass in a path to a policy file. This will supersede any other policy options
 
-    url = AWS::CF::Signer.sign_url('http://d84l721fxaaqy9.cloudfront.net/downloads/pictures.tgz', :policy_file => '/path/to/policy/file.txt')
+    url = Aws::CF::Signer.sign_url('http://d84l721fxaaqy9.cloudfront.net/downloads/pictures.tgz', :policy_file => '/path/to/policy/file.txt')
 
 
 ## Patches/Pull Requests


### PR DESCRIPTION
Hi I guess the casing should be camel cased for "Aws" Module.

Thanks